### PR TITLE
Adjust half-court projection for server Y coordinates

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -165,9 +165,15 @@ function computeLayout() {
   };
 }
 
+function projectServerYToHalfCourt(y) {
+  const SCALE_Y = HALF_H / VIRTUAL_H;
+  return HALF_Y_MIN + (y - HALF_Y_MIN) * SCALE_Y;
+}
+
 function worldToCanvas(x, y, layout) {
   const cx = (x - HALF_X_MIN) / HALF_W;
-  const clampedY = Math.max(HALF_Y_MIN, Math.min(HALF_Y_MAX, y));
+  const projectedY = projectServerYToHalfCourt(y);
+  const clampedY = Math.max(HALF_Y_MIN, Math.min(HALF_Y_MAX, projectedY));
   const cy = (clampedY - HALF_Y_MIN) / HALF_H;
 
   return {


### PR DESCRIPTION
## Summary
- scale server-provided Y coordinates into the half-court range before clamping
- rely on the shared worldToCanvas projection so players and play guides remain aligned

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfd7449ddc832f8c008f60e1e46e4c